### PR TITLE
CO-1878 verify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}
     # Should be inverse of `if` below
-    if: "!((github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged) || (startsWith(github.event_name, 'issue_comment') && contains(github.event.comment.body, '/qa')))"
+    if: "!((github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged) || (startsWith(github.event_name, 'issue_comment') && (startsWith(github.event.comment.body, '/qa') || startsWith(github.event.comment.body, '/verify'))))"
     steps:
     # These tasks do not actually need a copy of the repository because it only performs automation tasks with the GitHub API
     # - uses: actions/checkout@master
@@ -44,7 +44,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}
     # Should be inverse of `if` above
-    if: "((github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged) || (startsWith(github.event_name, 'issue_comment') && contains(github.event.comment.body, '/qa')))"
+    if: "((github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged) || (startsWith(github.event_name, 'issue_comment') && (startsWith(github.event.comment.body, '/qa') || startsWith(github.event.comment.body, '/verify'))))"
     steps:
     - uses: actions/checkout@master
     - uses: unbounce/actions-deploy@master

--- a/dist/index.js
+++ b/dist/index.js
@@ -37407,7 +37407,7 @@ exports.commandParameters = (context) => {
     // tslint:disable-next-line:no-shadowed-variable
     const { comment, issue, pull_request: pr } = context.payload;
     const parameters = (comment || issue || pr).body.match(/^\/[\w-]+\s*?(.*)?$/m);
-    if (parameters) {
+    if (parameters && parameters[1]) {
         return parameters[1].split(" ");
     }
     else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,8 +15,25 @@ import {
 export const commandMatches = (context: Context, match: string): boolean => {
   // tslint:disable-next-line:no-shadowed-variable
   const { comment, issue, pull_request: pr } = context.payload;
-  const command = (comment || issue || pr).body.match(/^\/([\w-]+)\s*?(.*)?$/m);
-  return command && command[1] === match;
+  const command = ((comment || issue || pr).body as string).match(
+    /^\/([\w-]+)\s*?(.*)?$/m
+  );
+  return Boolean(command && command[1] === match);
+};
+
+// Return parameters included with a command, for example a command like
+// `/deploy production abc123` will return ["production", "abc123"]
+export const commandParameters = (context: Context): string[] => {
+  // tslint:disable-next-line:no-shadowed-variable
+  const { comment, issue, pull_request: pr } = context.payload;
+  const parameters = ((comment || issue || pr).body as string).match(
+    /^\/[\w-]+\s*?(.*)?$/m
+  );
+  if (parameters) {
+    return parameters[1].split(" ");
+  } else {
+    return [];
+  }
 };
 
 export const createComment = (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ export const commandParameters = (context: Context): string[] => {
   const parameters = ((comment || issue || pr).body as string).match(
     /^\/[\w-]+\s*?(.*)?$/m
   );
-  if (parameters) {
+  if (parameters && parameters[1]) {
     return parameters[1].split(" ");
   } else {
     return [];


### PR DESCRIPTION
- Add `/verify` command to run `verify` commands on-demand
- Environment can optionally be passed as `/verify <environment>` (defaults to preproduction environment)
- The pull request will be checked out before running `verify` commands
- If the pull request is currently deployed, it's deployment status will be set to "success" if `verify` command succeeds