### PR TITLE
CO-1756 Monorepo Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,9 @@ jobs:
       GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}
     # Should be inverse of `if` below
     if: "(github.event_name == 'push' || (github.event_name == 'issue_comment' && !(startsWith(github.event.comment.body, '/qa') || startsWith(github.event.comment.body, '/deploy') || startsWith(github.event.comment.body, '/verify'))))"
-    defaults:
-      if: "(!env.ACTIONS_DEPLOY_NAME || github.event_name != 'issue_comment' || contains(github.event.issue.labels.*.name, 'actions-deploy/${env.ACTIONS_DEPLOY_NAME}'))"
     steps:
     - uses: unbounce/actions-deploy@master
+      if: "(!env.ACTIONS_DEPLOY_NAME || github.event_name != 'issue_comment' || contains(github.event.issue.labels.*.name, 'actions-deploy/${{env.ACTIONS_DEPLOY_NAME}}'))"
       with:
         release: make release # or: npm run release
         deploy: make deploy # or: npm run deploy --environment "$ENVIRONMENT" --version "$VERSION"
@@ -54,11 +53,11 @@ jobs:
       GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}
     # Should be inverse of `if` above
     if: "(github.event_name == 'push' || (github.event_name == 'issue_comment' && !(startsWith(github.event.comment.body, '/qa') || startsWith(github.event.comment.body, '/deploy') || startsWith(github.event.comment.body, '/verify'))))"
-    defaults:
-      if: "(!env.ACTIONS_DEPLOY_NAME || github.event_name != 'issue_comment' || contains(github.event.issue.labels.*.name, 'actions-deploy/${env.ACTIONS_DEPLOY_NAME}'))"
     steps:
     - uses: actions/checkout@master
+      if: "(!env.ACTIONS_DEPLOY_NAME || github.event_name != 'issue_comment' || contains(github.event.issue.labels.*.name, 'actions-deploy/${{env.ACTIONS_DEPLOY_NAME}}'))"
     - uses: unbounce/actions-deploy@master
+      if: "(!env.ACTIONS_DEPLOY_NAME || github.event_name != 'issue_comment' || contains(github.event.issue.labels.*.name, 'actions-deploy/${{env.ACTIONS_DEPLOY_NAME}}'))"
       with:
         setup: make deps # or: npm ci
         release: make release # or: npm run release

--- a/README.md
+++ b/README.md
@@ -10,26 +10,39 @@ Create a workflow in your repository (such as `.github/workflows/deployment.yaml
 on:
   pull_request:
     types: [opened, reopened, closed, synchronize]
+    # Scope to certain paths if more than one component in a repository uses the actions-deploy workflow
+    # paths:
+    #   - packages/my-component/*
   push:
     branches: [master]
+    # Scope to certain paths if more than one component in a repository uses the actions-deploy workflow
+    # paths:
+    #   - packages/my-component/*
   issue_comment: {}
+
+# Provide a name if more than one component in a repository use the actions-deploy workflow:
+# env:
+#   ACTIONS_DEPLOY_NAME: my-component
 
 name: Deployment
 jobs:
-
   # Deployment automation tasks
   automation:
-    name: Deployment Automation
+    name: Automation
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}
     # Should be inverse of `if` below
-    if: "(github.event_name == 'push' || (github.event_name == 'issue_comment' && !(startsWith(github.event.comment.body, '/qa') || startsWith(github.event.comment.body, '/deploy') || startsWith(github.event.comment.body, '/verify')))"
+    if: "(github.event_name == 'push' || (github.event_name == 'issue_comment' && !(startsWith(github.event.comment.body, '/qa') || startsWith(github.event.comment.body, '/deploy') || startsWith(github.event.comment.body, '/verify'))))"
+    defaults:
+      if: "(!env.ACTIONS_DEPLOY_NAME || github.event_name != 'issue_comment' || contains(github.event.issue.labels.*.name, 'actions-deploy/${env.ACTIONS_DEPLOY_NAME}'))"
     steps:
-    # These tasks do not actually need a copy of the repository because it only performs automation tasks with the GitHub API
-    # - uses: actions/checkout@master
     - uses: unbounce/actions-deploy@master
+      with:
+        release: make release # or: npm run release
+        deploy: make deploy # or: npm run deploy --environment "$ENVIRONMENT" --version "$VERSION"
+        verify: make end-to-end-tests
 
   # Deployment tasks - this is where the actual deployment takes place
   # Runs on self-hosted runners so that it can have access to AWS resources for deployments
@@ -40,7 +53,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}
     # Should be inverse of `if` above
-    if: "!(github.event_name == 'push' || (github.event_name == 'issue_comment' && !(startsWith(github.event.comment.body, '/qa') || startsWith(github.event.comment.body, '/deploy') || startsWith(github.event.comment.body, '/verify')))"
+    if: "(github.event_name == 'push' || (github.event_name == 'issue_comment' && !(startsWith(github.event.comment.body, '/qa') || startsWith(github.event.comment.body, '/deploy') || startsWith(github.event.comment.body, '/verify'))))"
+    defaults:
+      if: "(!env.ACTIONS_DEPLOY_NAME || github.event_name != 'issue_comment' || contains(github.event.issue.labels.*.name, 'actions-deploy/${env.ACTIONS_DEPLOY_NAME}'))"
     steps:
     - uses: actions/checkout@master
     - uses: unbounce/actions-deploy@master
@@ -56,6 +71,36 @@ request. This will create a release and deploy it to the pre-production
 environment. Then `/passed-qa` or `/failed-qa` should be commented once manual
 verification of the release is complete. Merging the pull request after
 commenting `/qa` will deploy the release to the production environment.
+
+### Multiple Components
+
+Monorepos or repositories that have more than one component must specify a
+unique name for the component (specified in the `ACTIONS_DEPLOY_NAME`
+environment variable). Specifying a name will create a separate GitHub
+Deployment environment to track deployments for that component. For example, a
+name of `infrastructure` will be tracked as `production[infrastructure]`.
+
+The workflow should be scoped to paths that are relevant for the component.
+
+```yaml
+on:
+  pull_request:
+    types: [opened, reopened, closed, synchronize]
+    paths:
+      - packages/my-component/*
+  push:
+    branches: [master]
+    paths:
+      - packages/my-component/*
+  issue_comment: {}
+
+env:
+  ACTIONS_DEPLOY_NAME: infrastructure
+```
+
+**Note** that you may choose to omit the `ACTIONS_DEPLOY_NAME` for the main
+component of your repository, but that only one actions-deploy workflow per
+repository can omit this property.
 
 ### Commands
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -26425,7 +26425,7 @@ const setup = async (comment) => {
 const release = async (comment, version) => {
     try {
         comment.separator();
-        await comment.append(`Releasing ${version}...`);
+        await comment.append(`Releasing ${utils_1.maybeComponentName()}${version}...`);
         const env = {
             VERSION: version,
         };
@@ -26437,18 +26437,18 @@ const release = async (comment, version) => {
         const output = await shell_1.shell(commands, env);
         await comment.append([
             comment_1.logToDetails(output),
-            comment_1.success(`${version} was successfully released.`),
+            comment_1.success(`${utils_1.maybeComponentName()}${version} was successfully released.`),
         ]);
     }
     catch (e) {
-        await utils_1.handleError(comment, `releaseing ${version} failed`, e);
+        await utils_1.handleError(comment, `releaseing ${utils_1.maybeComponentName()}${version} failed`, e);
         throw e;
     }
 };
 const deploy = async (comment, version, environment) => {
     try {
         comment.separator();
-        await comment.append(`Deploying ${version} to ${comment_1.code(environment)}...`);
+        await comment.append(`Deploying ${utils_1.maybeComponentName()}${version} to ${comment_1.code(environment)}...`);
         const env = {
             VERSION: version,
             ENVIRONMENT: environment,
@@ -26461,18 +26461,18 @@ const deploy = async (comment, version, environment) => {
         const output = await shell_1.shell(commands, env);
         await comment.append([
             comment_1.logToDetails(output),
-            comment_1.success(`${version} was successfully deployed to ${comment_1.code(environment)}.`),
+            comment_1.success(`${utils_1.maybeComponentName()}${version} was successfully deployed to ${comment_1.code(environment)}.`),
         ]);
     }
     catch (e) {
-        await utils_1.handleError(comment, `deploying ${version} to ${comment_1.code(environment)} failed`, e);
+        await utils_1.handleError(comment, `deploying ${utils_1.maybeComponentName()}${version} to ${comment_1.code(environment)} failed`, e);
         throw e;
     }
 };
 const verify = async (comment, version, environment) => {
     try {
         comment.separator();
-        await comment.append(`Verifying ${version} in ${comment_1.code(environment)}...`);
+        await comment.append(`Verifying ${utils_1.maybeComponentName()}${version} in ${comment_1.code(environment)}...`);
         const env = {
             VERSION: version,
             ENVIRONMENT: environment,
@@ -26485,11 +26485,11 @@ const verify = async (comment, version, environment) => {
         const output = await shell_1.shell(commands, env);
         await comment.append([
             comment_1.logToDetails(output),
-            comment_1.success(`${version} was successfully verified in ${comment_1.code(environment)}.`),
+            comment_1.success(`${utils_1.maybeComponentName()}${version} was successfully verified in ${comment_1.code(environment)}.`),
         ]);
     }
     catch (e) {
-        await utils_1.handleError(comment, `verifying ${version} in ${comment_1.code(environment)} failed`, e);
+        await utils_1.handleError(comment, `verifying ${utils_1.maybeComponentName()}${version} in ${comment_1.code(environment)} failed`, e);
         throw e;
     }
 };
@@ -26529,12 +26529,12 @@ const handlePrMerged = async (context, pr) => {
             // Rollback
             const previousDeployment = await utils_1.findPreviousDeployment(context, environment);
             if (!previousDeployment) {
-                await comment.append(comment_1.warning(`Unable to find previous deployment for ${comment_1.code(environment)} to roll back to.`));
+                await comment.append(comment_1.warning(`Unable to find previous deployment for ${utils_1.maybeComponentName()}${comment_1.code(environment)} to roll back to.`));
                 // Re-throw so that first deployment is marked as "error"
                 throw e;
             }
             const previousVersion = await git_1.getShortSha(previousDeployment.sha);
-            await comment.append(comment_1.warning(`Rolling back ${comment_1.code(environment)} to ${previousVersion}...`));
+            await comment.append(comment_1.warning(`Rolling back ${utils_1.maybeComponentName()}${comment_1.code(environment)} to ${previousVersion}...`));
             await createDeploymentAndSetStatus(context, previousVersion, environment, { pr: utils_1.deploymentPullRequestNumber(previousDeployment) }, async () => {
                 await deploy(comment, previousVersion, environment);
                 await verify(comment, previousVersion, environment);
@@ -26580,7 +26580,7 @@ const handleQACommand = async (context, pr) => {
     }
     else {
         const prNumber = utils_1.deploymentPullRequestNumber(deployment);
-        const message = `#${prNumber} is currently deployed to ${comment_1.code(environment)}. It must be merged or closed before this pull request can be deployed.`;
+        const message = `#${prNumber} is currently deployed ${utils_1.maybeComponentName()}to ${comment_1.code(environment)}. It must be merged or closed before this pull request can be deployed.`;
         await utils_1.createComment(context, pr.number, [comment_1.mention(message)]);
         log.error(message);
     }
@@ -26649,7 +26649,7 @@ const resetPreProductionDeployment = async (context) => {
         await deploy(comment, version, environment);
         await verify(comment, version, environment);
     });
-    await comment.append(comment_1.success(`Reset ${comment_1.code(preProductionEnvironment)} to version ${version} from ${comment_1.code(productionEnvironment)}.`));
+    await comment.append(comment_1.success(`Reset ${comment_1.code(preProductionEnvironment)} ${utils_1.maybeComponentName()}to version ${version} from ${comment_1.code(productionEnvironment)}.`));
 };
 const updateOutdatedDeployment = async (context, pr) => {
     const { preProductionEnvironment } = config_1.config;
@@ -37563,6 +37563,7 @@ exports.environmentWithComponent = (environment) => {
     }
 };
 exports.componentLabel = () => `actions-deploy/${config_1.config.componentName}`;
+exports.maybeComponentName = () => config_1.config.componentName ? `${comment.code(config_1.config.componentName)} ` : "";
 // From https://github.com/probot/commands/blob/master/index.js
 exports.commandMatches = (context, match) => {
     // tslint:disable-next-line:no-shadowed-variable

--- a/dist/index.js
+++ b/dist/index.js
@@ -26548,7 +26548,7 @@ const handlePrMerged = async (context, pr) => {
 const handleQACommand = async (context, pr) => {
     const environment = config_1.config.preProductionEnvironment;
     const deployment = await utils_1.findDeployment(context, environment);
-    if (utils_1.environmentIsAvailable(context, deployment)) {
+    if (await utils_1.environmentIsAvailable(context, deployment)) {
         await git_1.checkoutPullRequest(pr);
         const comment = new comment_1.Comment(context, context.issue().number);
         await comment.append(`Running ${comment_1.code("/qa")}...`);
@@ -26557,7 +26557,7 @@ const handleQACommand = async (context, pr) => {
             await git_1.updatePullRequest(pr);
         }
         catch (e) {
-            await utils_1.handleError(comment, `I failed to bring ${pr.head.ref} up-to-date with ${pr.base.ref}. Please resolve conflicts before running /qa again.`, e);
+            await utils_1.handleError(comment, `I failed to bring ${pr.head.ref} up-to-date with ${pr.base.ref}. Please resolve conflicts before running ${comment_1.code("/qa")} again.`, e);
             return;
         }
         const version = await git_1.getShortSha("HEAD");

--- a/dist/index.js
+++ b/dist/index.js
@@ -26586,7 +26586,7 @@ const handleQACommand = async (context, pr) => {
     else {
         const prNumber = utils_1.deploymentPullRequestNumber(deployment);
         const message = `#${prNumber} is currently deployed ${utils_1.maybeComponentName()}to ${comment_1.code(environment)}. It must be merged or closed before this pull request can be deployed.`;
-        await comment_1.Comment.create(context, pr.number, comment_1.mention(message));
+        await comment_1.Comment.create(context, pr.number, comment_1.warning(comment_1.mention(message)));
         log.error(message);
     }
 };
@@ -26609,7 +26609,7 @@ const invalidateDeployedPullRequest = async (context) => {
             if (baseRef === deployedPr.data.base.ref) {
                 log.debug(`The pull request currently deployed to ${environment} (#${deployedPr}) has the same base (${baseRef}) - invalidating it`);
                 const body = [
-                    `This pull request is no longer up-to-date with ${baseRef} (because #${prNumber} was just merged, which changed ${baseRef}).`,
+                    comment_1.warning(`This pull request is no longer up-to-date with ${baseRef} (because #${prNumber} was just merged, which changed ${baseRef}).`),
                     `Run ${comment_1.code("/qa")} to redeploy your changes to ${comment_1.code(environment)} or ${comment_1.code("/skip-qa")} if you want to ignore the changes in ${baseRef}.`,
                     `Note that using ${comment_1.code("/skip-qa")} will cause the new changes in ${baseRef} to be excluded when this pull request is merged, and they will not be deployed to ${comment_1.code(config_1.config.productionEnvironment)}.`,
                 ].join(" ");
@@ -26693,7 +26693,7 @@ const handleVerifyCommand = async (context, pr, providedEnvironment) => {
     const comment = new comment_1.Comment(context, context.issue().number);
     await comment.append(`Running ${comment_1.code(`/verify ${environment}`)}...`);
     if (!deployment) {
-        await comment.append(`I wasn't able to find a deployment for ${comment_1.code(environment)} to verify.`);
+        await comment.append(comment_1.warning(`I wasn't able to find a deployment for ${comment_1.code(environment)} to verify.`));
         return;
     }
     await git_1.checkoutPullRequest(pr);
@@ -26722,7 +26722,7 @@ const handleDeployCommand = async (context, pr, providedEnvironment, providedVer
     if (!deployment) {
         await comment.append([
             `Running ${comment_1.code(`/deploy`)}...`,
-            `I wasn't able to find the latest release for #${pr.number}`,
+            comment_1.warning(`I wasn't able to find the latest release for #${pr.number}`),
         ]);
         return;
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   coverageReporters: ['lcov', 'text'],
   preset: 'ts-jest',
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  setupFiles: ["<rootDir>/jest.setup.js"]
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,7 @@
+process.env['INPUT_RELEASE'] = 'echo release';
+process.env['INPUT_DEPLOY'] = 'echo deploy';
+process.env['INPUT_VERIFY'] = 'echo verify';
+process.env['INPUT_SETUP'] = 'echo setup';
+process.env['INPUT_MAIN-BRANCH'] = 'master';
+process.env['INPUT_PRODUCTION-ENVIRONMENT'] = 'production';
+process.env['INPUT_PRE-PRODUCTION-ENVIRONMENT'] = 'pre-production';

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -108,6 +108,16 @@ export class Comment {
     this.footer = [`---`, `(${runLink("Details")})`];
   }
 
+  static async create(
+    context: Context,
+    issueNumber: number,
+    body: string | string[]
+  ) {
+    const comment = new Comment(context, issueNumber);
+    await comment.append(body);
+    return comment;
+  }
+
   async append(lines: string | string[]) {
     this.lines = this.lines.concat(lines);
     await this.apply(this.lines);

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,8 @@ const input = (name: string) => {
 };
 
 export const config = {
+  isComponent: "ACTIONS_DEPLOY_NAME" in process.env,
+  componentName: process.env[`ACTIONS_DEPLOY_NAME`],
   statusCheckContext: "QA",
   productionEnvironment: input("production-environment"),
   preProductionEnvironment: input("pre-production-environment"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -334,7 +334,7 @@ const handleQACommand = async (context: Context, pr: PullRequest) => {
     const message = `#${prNumber} is currently deployed ${maybeComponentName()}to ${code(
       environment
     )}. It must be merged or closed before this pull request can be deployed.`;
-    await Comment.create(context, pr.number, mention(message));
+    await Comment.create(context, pr.number, warning(mention(message)));
     log.error(message);
   }
 };
@@ -365,7 +365,9 @@ const invalidateDeployedPullRequest = async (
           `The pull request currently deployed to ${environment} (#${deployedPr}) has the same base (${baseRef}) - invalidating it`
         );
         const body = [
-          `This pull request is no longer up-to-date with ${baseRef} (because #${prNumber} was just merged, which changed ${baseRef}).`,
+          warning(
+            `This pull request is no longer up-to-date with ${baseRef} (because #${prNumber} was just merged, which changed ${baseRef}).`
+          ),
           `Run ${code("/qa")} to redeploy your changes to ${code(
             environment
           )} or ${code(
@@ -514,7 +516,9 @@ const handleVerifyCommand = async (
 
   if (!deployment) {
     await comment.append(
-      `I wasn't able to find a deployment for ${code(environment)} to verify.`
+      warning(
+        `I wasn't able to find a deployment for ${code(environment)} to verify.`
+      )
     );
     return;
   }
@@ -567,7 +571,7 @@ const handleDeployCommand = async (
   if (!deployment) {
     await comment.append([
       `Running ${code(`/deploy`)}...`,
-      `I wasn't able to find the latest release for #${pr.number}`,
+      warning(`I wasn't able to find the latest release for #${pr.number}`),
     ]);
     return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,7 @@ const handleQACommand = async (context: Context, pr: PullRequest) => {
   const environment = config.preProductionEnvironment;
   const deployment = await findDeployment(context, environment);
 
-  if (environmentIsAvailable(context, deployment)) {
+  if (await environmentIsAvailable(context, deployment)) {
     await checkoutPullRequest(pr);
     const comment = new Comment(context, context.issue().number);
     await comment.append(`Running ${code("/qa")}...`);
@@ -294,7 +294,9 @@ const handleQACommand = async (context: Context, pr: PullRequest) => {
     } catch (e) {
       await handleError(
         comment,
-        `I failed to bring ${pr.head.ref} up-to-date with ${pr.base.ref}. Please resolve conflicts before running /qa again.`,
+        `I failed to bring ${pr.head.ref} up-to-date with ${
+          pr.base.ref
+        }. Please resolve conflicts before running ${code("/qa")} again.`,
         e
       );
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   handleError,
   pullRequestHasBeenDeployed,
   findLastDeploymentForPullRequest,
+  maybeComponentName,
 } from "./utils";
 import * as log from "./logging";
 import { shell } from "./shell";
@@ -70,7 +71,7 @@ const setup = async (comment: Comment) => {
 const release = async (comment: Comment, version: string) => {
   try {
     comment.separator();
-    await comment.append(`Releasing ${version}...`);
+    await comment.append(`Releasing ${maybeComponentName()}${version}...`);
     const env = {
       VERSION: version,
     };
@@ -82,10 +83,14 @@ const release = async (comment: Comment, version: string) => {
     const output = await shell(commands, env);
     await comment.append([
       logToDetails(output),
-      success(`${version} was successfully released.`),
+      success(`${maybeComponentName()}${version} was successfully released.`),
     ]);
   } catch (e) {
-    await handleError(comment, `releaseing ${version} failed`, e);
+    await handleError(
+      comment,
+      `releaseing ${maybeComponentName()}${version} failed`,
+      e
+    );
     throw e;
   }
 };
@@ -97,7 +102,9 @@ const deploy = async (
 ) => {
   try {
     comment.separator();
-    await comment.append(`Deploying ${version} to ${code(environment)}...`);
+    await comment.append(
+      `Deploying ${maybeComponentName()}${version} to ${code(environment)}...`
+    );
     const env = {
       VERSION: version,
       ENVIRONMENT: environment,
@@ -110,12 +117,18 @@ const deploy = async (
     const output = await shell(commands, env);
     await comment.append([
       logToDetails(output),
-      success(`${version} was successfully deployed to ${code(environment)}.`),
+      success(
+        `${maybeComponentName()}${version} was successfully deployed to ${code(
+          environment
+        )}.`
+      ),
     ]);
   } catch (e) {
     await handleError(
       comment,
-      `deploying ${version} to ${code(environment)} failed`,
+      `deploying ${maybeComponentName()}${version} to ${code(
+        environment
+      )} failed`,
       e
     );
     throw e;
@@ -129,7 +142,9 @@ const verify = async (
 ) => {
   try {
     comment.separator();
-    await comment.append(`Verifying ${version} in ${code(environment)}...`);
+    await comment.append(
+      `Verifying ${maybeComponentName()}${version} in ${code(environment)}...`
+    );
     const env = {
       VERSION: version,
       ENVIRONMENT: environment,
@@ -142,12 +157,18 @@ const verify = async (
     const output = await shell(commands, env);
     await comment.append([
       logToDetails(output),
-      success(`${version} was successfully verified in ${code(environment)}.`),
+      success(
+        `${maybeComponentName()}${version} was successfully verified in ${code(
+          environment
+        )}.`
+      ),
     ]);
   } catch (e) {
     await handleError(
       comment,
-      `verifying ${version} in ${code(environment)} failed`,
+      `verifying ${maybeComponentName()}${version} in ${code(
+        environment
+      )} failed`,
       e
     );
     throw e;
@@ -224,7 +245,7 @@ const handlePrMerged = async (
         if (!previousDeployment) {
           await comment.append(
             warning(
-              `Unable to find previous deployment for ${code(
+              `Unable to find previous deployment for ${maybeComponentName()}${code(
                 environment
               )} to roll back to.`
             )
@@ -235,7 +256,11 @@ const handlePrMerged = async (
 
         const previousVersion = await getShortSha(previousDeployment.sha);
         await comment.append(
-          warning(`Rolling back ${code(environment)} to ${previousVersion}...`)
+          warning(
+            `Rolling back ${maybeComponentName()}${code(
+              environment
+            )} to ${previousVersion}...`
+          )
         );
         await createDeploymentAndSetStatus(
           context,
@@ -305,7 +330,7 @@ const handleQACommand = async (context: Context, pr: PullRequest) => {
     );
   } else {
     const prNumber = deploymentPullRequestNumber(deployment);
-    const message = `#${prNumber} is currently deployed to ${code(
+    const message = `#${prNumber} is currently deployed ${maybeComponentName()}to ${code(
       environment
     )}. It must be merged or closed before this pull request can be deployed.`;
     await createComment(context, pr.number, [mention(message)]);
@@ -418,7 +443,9 @@ const resetPreProductionDeployment = async (
     success(
       `Reset ${code(
         preProductionEnvironment
-      )} to version ${version} from ${code(productionEnvironment)}.`
+      )} ${maybeComponentName()}to version ${version} from ${code(
+        productionEnvironment
+      )}.`
     )
   );
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,16 @@ import {
   CommitStatusState,
 } from "./types";
 
+export const environmentWithComponent = (environment: string) => {
+  if (config.isComponent) {
+    return `${environment}[${config.componentName}]`;
+  } else {
+    return environment;
+  }
+};
+
+export const componentLabel = () => `actions-deploy/${config.componentName}`;
+
 // From https://github.com/probot/commands/blob/master/index.js
 export const commandMatches = (context: Context, match: string): boolean => {
   // tslint:disable-next-line:no-shadowed-variable
@@ -71,7 +81,7 @@ export const setCommitStatus = async (
 
 export const findDeployment = async (context: Context, environment: string) => {
   const deployments = await context.github.repos.listDeployments(
-    context.repo({ environment })
+    context.repo({ environment: environmentWithComponent(environment) })
   );
   if (deployments.data.length === 1) {
     return deployments.data[0];
@@ -99,7 +109,7 @@ export const findPreviousDeployment = async (
   environment: string
 ) => {
   const deployments = await context.github.repos.listDeployments(
-    context.repo({ environment })
+    context.repo({ environment: environmentWithComponent(environment) })
   );
   if (deployments.data.length > 1) {
     const [latestDeployment, previousDeployment] = deployments.data;
@@ -169,7 +179,7 @@ export const createDeployment = (
       payload: JSON.stringify(payload),
       required_contexts: [],
       auto_merge: false,
-      environment,
+      environment: environmentWithComponent(environment),
       ref,
     })
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,9 @@ export const environmentWithComponent = (environment: string) => {
 
 export const componentLabel = () => `actions-deploy/${config.componentName}`;
 
+export const maybeComponentName = () =>
+  config.componentName ? `${comment.code(config.componentName)} ` : "";
+
 // From https://github.com/probot/commands/blob/master/index.js
 export const commandMatches = (context: Context, match: string): boolean => {
   // tslint:disable-next-line:no-shadowed-variable

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,20 +49,6 @@ export const commandParameters = (context: Context): string[] => {
   }
 };
 
-export const createComment = (
-  context: Context,
-  issueNumber: number,
-  body0: string | string[]
-) => {
-  const body = typeof body0 === "string" ? body0 : body0.join("\n");
-  const issueComment = context.repo({
-    issue_number: issueNumber,
-    body,
-  });
-
-  return context.github.issues.createComment(issueComment);
-};
-
 export const setCommitStatus = async (
   context: Context,
   pr: PullRequest,


### PR DESCRIPTION
This pull request adds support for repositories that contain more than one deployable component. Each component gets its own GitHub Actions workflow and is uniquely identified by the `ACTIONS_DEPLOY_NAME` environment variable. Each workflow can specify its own `paths` on which it should be triggered.

There are a couple drawbacks to this:
- there can be a race-condition between multiple workflows that get triggered for the same workflow when bringing the branch up-to-date with master
  - if the pull request is behind master and `/qa` is run, and more than one component is changed, each will try to bring the branch up-to-date-with master at the same time
  - from my testing I haven't run into this yet as workflows don't typically start running at exactly the same time
- commands (`/qa`, `/deploy` (including "rollbacks"), `/verify`) can only target all components that changed in a pull request (you can't currently run a command targeting just one component changed by a pull request)
- a label is used to track which components are relevant for a pull request (because the `issue_comment` event can't use the `paths` filters)

