### PR TITLE
CO-1756 Monorepo

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26516,6 +26516,7 @@ const handlePrMerged = async (context, pr) => {
     const deploymentStatus = await utils_1.getDeploymentStatus(context, deployment.id);
     if (deploymentStatus !== "success") {
         await comment.append(comment_1.error(comment_1.mention(`The ${utils_1.maybeComponentName()}${comment_1.code(preProductionEnvironment)} deployment resulted in ${comment_1.code(deploymentStatus || "unknown")} - not deploying to ${comment_1.code(productionEnvironment)}.`)));
+        return;
     }
     await comment.append(comment_1.mention(`Deploying to ${comment_1.code(productionEnvironment)}...`));
     await setup(comment);

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,7 @@ const handlePrMerged = async (
         )
       )
     );
+    return;
   }
 
   await comment.append(

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   createDeployment,
   findDeployment,
   findPreviousDeployment,
+  getDeploymentStatus,
   environmentIsAvailable,
   deploymentPullRequestNumber,
   handleError,
@@ -27,6 +28,7 @@ import {
   mention,
   code,
   logToDetails,
+  error,
   warning,
   success,
   info,
@@ -196,35 +198,33 @@ const handlePrMerged = async (
     return;
   }
 
-  if (deployment.sha !== pr.head.sha) {
-    const message = [
-      warning(
-        `️The deployment to ${code(
-          preProductionEnvironment
-        )} was outdated, so I skipped deployment to ${code(
-          productionEnvironment
-        )}.`
-      ),
-      mention(
-        `, please check ${code(pr.base.ref)} and deploy manually if necessary.`
-      ),
-    ];
-
-    await Comment.create(context, pr.number, message);
-    return;
-  }
-
   log.debug(
     `${pr.number} was merged, and is currently deployed to ${preProductionEnvironment} - deploying it to ${productionEnvironment}`
   );
 
   const comment = new Comment(context, context.issue().number);
+
+  const deploymentStatus = await getDeploymentStatus(context, deployment.id);
+  if (deploymentStatus !== "success") {
+    await comment.append(
+      error(
+        mention(
+          `The ${maybeComponentName()}${code(
+            preProductionEnvironment
+          )} deployment resulted in ${code(
+            deploymentStatus || "unknown"
+          )} - not deploying to ${code(productionEnvironment)}.`
+        )
+      )
+    );
+  }
+
   await comment.append(
     mention(`Deploying to ${code(productionEnvironment)}...`)
   );
 
   await setup(comment);
-  const version = await getShortSha(deployment.sha);
+  const version = deployment.ref;
   const environment = productionEnvironment;
   await createDeploymentAndSetStatus(
     context,
@@ -253,7 +253,7 @@ const handlePrMerged = async (
           throw e;
         }
 
-        const previousVersion = await getShortSha(previousDeployment.sha);
+        const previousVersion = previousDeployment.ref;
         await comment.append(
           warning(
             `Rolling back ${maybeComponentName()}${code(
@@ -428,7 +428,7 @@ const resetPreProductionDeployment = async (
   }
 
   const comment = new Comment(context, context.issue().number);
-  const version = await getShortSha(prodDeployment.sha);
+  const version = prodDeployment.ref;
   const environment = preProductionEnvironment;
 
   await createDeploymentAndSetStatus(
@@ -528,7 +528,7 @@ const handleVerifyCommand = async (
   await setup(comment);
 
   try {
-    const version = await getShortSha(deployment.sha);
+    const version = deployment.ref;
     await verify(comment, version, environment);
 
     if (environment === config.preProductionEnvironment) {
@@ -578,8 +578,7 @@ const handleDeployCommand = async (
 
   await checkoutPullRequest(pr);
 
-  const deploymentVersion = await getShortSha(deployment.sha);
-  const version = providedVersion || deploymentVersion;
+  const version = providedVersion || deployment.ref;
 
   await comment.append(
     `Running ${code(`/deploy ${environment} ${version}`)}...`


### PR DESCRIPTION
Follow on to #13 

- allow out of date pull requests to trigger a production deploy
  - a change to master does not always indicate that a component of a monorepo is now out of date
  - the developer will still be given a warning if a change to master is relevant for their pull request (based on the `paths` filter, and the QA status check would be set to pending in that case)
- ~warn if QA status check is not configured when a pull request is opened~ it is not possible to determine if the status check is required with the permissions available to an action